### PR TITLE
Add force checkout to cleanup changes from ncc

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ async function run() {
         } else {
             console.log("Node js module is up to date.");
         }
+        await git.checkout(branch, ['-f']);
     } catch(error) {
         core.setFailed(error);
     }

--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ async function run() {
         } else {
             console.log("Node js module is up to date.");
         }
-        await git.pull(branch, ['-f']);
-        console.log("Git pull successfull");
+        await git.reset('hard');
+        console.log('Reset local changes');
     } catch(error) {
         core.setFailed(error);
     }

--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ async function run() {
         } else {
             console.log("Node js module is up to date.");
         }
-        await git.checkout(branch, ['-f']);
+        await git.pull(branch, ['-f']);
+        console.log("Git pull successfull");
     } catch(error) {
         core.setFailed(error);
     }


### PR DESCRIPTION
After installing `@vercel/ncc` the local `package.json` and `package-lock.json` are modified during the build process of the action. This force checks out the branch and undoes changes made to package.json and package-lock.json.